### PR TITLE
change hackrf i/o from default char to explicit int8_t

### DIFF
--- a/lib/hackrf/hackrf_sink_c.cc
+++ b/lib/hackrf/hackrf_sink_c.cc
@@ -218,7 +218,7 @@ hackrf_sink_c::hackrf_sink_c (const std::string &args)
 
   set_if_gain( 16 ); /* preset to a reasonable default (non-GRC use case) */
 
-  _buf = (char *) malloc( BUF_LEN );
+  _buf = (int8_t *) malloc( BUF_LEN );
 
   cb_init( &_cbuf, _buf_num, BUF_LEN );
 
@@ -326,7 +326,7 @@ bool hackrf_sink_c::stop()
 }
 
 #ifdef USE_AVX
-void convert_avx(const float* inbuf, char* outbuf,const unsigned int count)
+void convert_avx(const float* inbuf, int8_t* outbuf,const unsigned int count)
 {
   __m256 mulme = _mm256_set_ps(127.0f, 127.0f, 127.0f, 127.0f, 127.0f, 127.0f, 127.0f, 127.0f);
   for(unsigned int i=0; i<count;i++){
@@ -349,7 +349,7 @@ void convert_avx(const float* inbuf, char* outbuf,const unsigned int count)
 }
 
 #elif USE_SSE2
-void convert_sse2(const float* inbuf, char* outbuf,const unsigned int count)
+void convert_sse2(const float* inbuf, int8_t* outbuf,const unsigned int count)
 {
   const register __m128 mulme = _mm_set_ps( 127.0f, 127.0f, 127.0f, 127.0f );
   __m128 itmp1,itmp2,itmp3,itmp4;
@@ -380,7 +380,7 @@ void convert_sse2(const float* inbuf, char* outbuf,const unsigned int count)
 }
 #endif
 
-void convert_default(float* inbuf, char* outbuf,const unsigned int count)
+void convert_default(float* inbuf, int8_t* outbuf,const unsigned int count)
 {
   for(unsigned int i=0; i<count;i++){
     outbuf[i]= inbuf[i]*127;
@@ -400,7 +400,7 @@ int hackrf_sink_c::work( int noutput_items,
       _buf_cond.wait( lock );
   }
 
-  char *buf = _buf + _buf_used;
+  int8_t *buf = _buf + _buf_used;
   unsigned int prev_buf_used = _buf_used;
 
   unsigned int remaining = (BUF_LEN-_buf_used)/2; //complex

--- a/lib/hackrf/hackrf_sink_c.h
+++ b/lib/hackrf/hackrf_sink_c.h
@@ -134,7 +134,7 @@ private:
 //  gr::thread::thread _thread;
 
   circular_buffer_t _cbuf;
-  char *_buf;
+  int8_t *_buf;
   unsigned int _buf_num;
   unsigned int _buf_used;
   boost::mutex _buf_mutex;

--- a/lib/hackrf/hackrf_source_c.cc
+++ b/lib/hackrf/hackrf_source_c.cc
@@ -119,12 +119,15 @@ hackrf_source_c::hackrf_source_c (const std::string &args)
 
   // create a lookup table for gr_complex values
   for (unsigned int i = 0; i <= 0xffff; i++) {
+    //
+    // Note that the hackrf uses signed 8-bit integers
+    //
 #ifdef BOOST_LITTLE_ENDIAN
-    _lut.push_back( gr_complex( (float(char(i & 0xff))) * (1.0f/128.0f),
-                                (float(char(i >> 8))) * (1.0f/128.0f) ) );
+    _lut.push_back( gr_complex( (float(int8_t(i & 0xff))) * (1.0f/128.0f),
+                                (float(int8_t(i >> 8))) * (1.0f/128.0f) ) );
 #else // BOOST_BIG_ENDIAN
-    _lut.push_back( gr_complex( (float(char(i >> 8))) * (1.0f/128.0f),
-                                (float(char(i & 0xff))) * (1.0f/128.0f) ) );
+    _lut.push_back( gr_complex( (float(int8_t(i >> 8))) * (1.0f/128.0f),
+                                (float(int8_t(i & 0xff))) * (1.0f/128.0f) ) );
 #endif
   }
 


### PR DESCRIPTION
The HackRF uses signed char (int8_t) data types. Compilers for the x86 family of processors usually default "char" to "signed char", but e.g. compilers for the ARM family default to "unsigned char" ( see http://blog.cdleary.com/2012/11/arm-chars-are-unsigned-by-default/ ).

This results in errors in the processed data when using the HackRF on an ARM processor.

This change set uses int8_t to make the type casting explicit.
