### PR TITLE
Fixes conversion sign issue for hackrf on the raspberry pi.

### DIFF
--- a/lib/hackrf/hackrf_source_c.cc
+++ b/lib/hackrf/hackrf_source_c.cc
@@ -125,11 +125,11 @@ hackrf_source_c::hackrf_source_c (const std::string &args)
   // create a lookup table for gr_complex values
   for (unsigned int i = 0; i <= 0xffff; i++) {
 #ifdef BOOST_LITTLE_ENDIAN
-    _lut.push_back( gr_complex( (float(char(i & 0xff))) * (1.0f/128.0f),
-                                (float(char(i >> 8))) * (1.0f/128.0f) ) );
+    _lut.push_back( gr_complex( (float(int8_t(i & 0xff))) * (1.0f/128.0f),
+                                (float(int8_t(i >> 8))) * (1.0f/128.0f) ) );
 #else // BOOST_BIG_ENDIAN
-    _lut.push_back( gr_complex( (float(char(i >> 8))) * (1.0f/128.0f),
-                                (float(char(i & 0xff))) * (1.0f/128.0f) ) );
+    _lut.push_back( gr_complex( (float(int8_t(i >> 8))) * (1.0f/128.0f),
+                                (float(int8_t(i & 0xff))) * (1.0f/128.0f) ) );
 #endif
   }
 


### PR DESCRIPTION
Found an issue on the raspberry pi 2, using Raspbian Jessie.  The signed conversion using a char simply wasn't working.  Perhaps this is an issue across arm? Regardless, changing char->int8_t fixes it and shouldn't break any system that was using char.
