### PR TITLE
Added support for Nuand bladeRF XB300 amplifier

### DIFF
--- a/lib/bladerf/bladerf_common.h
+++ b/lib/bladerf/bladerf_common.h
@@ -98,6 +98,7 @@ protected:
   std::string _pfx;
 
   bool _xb_200_attached;
+  bool _xb_300_attached;
   unsigned int _consecutive_failures;
 
   /* BladeRF IQ correction parameters */


### PR DESCRIPTION
I added support for Nuand's bladeRF XB-300 amplifier, so that it can be configured via the device string. I tested all combinations of input values and verified proper operation of the device.
