### PR TITLE
Fix Airspy Missing Mixer Gain

### DIFF
--- a/lib/airspy/airspy_source_c.h
+++ b/lib/airspy/airspy_source_c.h
@@ -112,6 +112,7 @@ public:
   double set_lna_gain( double gain, size_t chan = 0 );
   double set_mix_gain(double gain, size_t chan = 0 );
   double set_if_gain( double gain, size_t chan = 0 );
+  double set_bb_gain( double gain, size_t chan = 0 ) { return set_mix_gain(gain, chan); };
 
   std::vector< std::string > get_antennas( size_t chan = 0 );
   std::string set_antenna( const std::string & antenna, size_t chan = 0 );


### PR DESCRIPTION
-   Issue http://gnuradio.org/redmine/issues/834
-   Airspy plugin didn't correctly set Mixer Gain in GNU Radio
