### PR TITLE
Prevent division by zero in gnuradio slider when B200 returns a zero …

### DIFF
--- a/apps/osmocom_siggen
+++ b/apps/osmocom_siggen
@@ -310,7 +310,7 @@ class app_gui(pubsub):
                     key=osmocom_siggen.BWIDTH_KEY,
                     minimum=bw_range.start(),
                     maximum=bw_range.stop(),
-                    step_size=bw_range.step(),
+                    step_size=None if bw_range.step()==0 else bw_range.step(),
                 )
                 bwidth_hbox.AddSpacer(3)
 


### PR DESCRIPTION
When I run osmocom_siggen on a Ettus B200 I would get the following error

Traceback (most recent call last):
  File "/usr/local/bin/osmocom_siggen", line 494, in <module>
    if __name__ == "__main__": main()
  File "/usr/local/bin/osmocom_siggen", line 480, in main
    realtime=True)                    # Whether to set realtime priority
  File "/usr/local/lib64/python2.7/site-packages/gnuradio/wxgui/gui.py", line 127, in __init__
    wx.App.__init__ (self, redirect=False)
  File "/usr/lib64/python2.7/site-packages/wx-3.0-gtk3/wx/_core.py", line 8628, in __init__
    self._BootstrapApp()
  File "/usr/lib64/python2.7/site-packages/wx-3.0-gtk3/wx/_core.py", line 8196, in _BootstrapApp
    return _core_.PyApp__BootstrapApp(*args, **kwargs)
  File "/usr/local/lib64/python2.7/site-packages/gnuradio/wxgui/gui.py", line 132, in OnInit
    self.title, self.nstatus, self.start, self.realtime)
  File "/usr/local/lib64/python2.7/site-packages/gnuradio/wxgui/gui.py", line 83, in __init__
    self.panel = top_panel(self, top_block, gui, options, args)
  File "/usr/local/lib64/python2.7/site-packages/gnuradio/wxgui/gui.py", line 42, in __init__
    args)           # Command-line arguments
  File "/usr/local/bin/osmocom_siggen", line 45, in __init__
    self.build_gui()
  File "/usr/local/bin/osmocom_siggen", line 313, in build_gui
    step_size=bw_range.step(),
  File "/usr/local/lib64/python2.7/site-packages/gnuradio/wxgui/forms/forms.py", line 279, in __init__
    if step_size is not None: num_steps = (maximum - minimum)/step_size
ZeroDivisionError: float division by zero
