### PR TITLE
uhd: add clock_source= parameter

### DIFF
--- a/lib/uhd/uhd_sink_c.cc
+++ b/lib/uhd/uhd_sink_c.cc
@@ -80,6 +80,7 @@ uhd_sink_c::uhd_sink_c(const std::string &args) :
          "nchan" == entry.first ||
          "subdev" == entry.first ||
          "lo_offset" == entry.first ||
+         "clock_source" == entry.first ||
          "uhd" == entry.first )
       continue;
 
@@ -108,6 +109,9 @@ uhd_sink_c::uhd_sink_c(const std::string &args) :
 
   if (dict.count("subdev"))
     _snk->set_subdev_spec( dict["subdev"] );
+
+  if (dict.count("clock_source"))
+    _snk->set_clock_source( dict["clock_source"] );
 
   std::cerr << "-- Using subdev spec '" << _snk->get_subdev_spec() << "'."
             << std::endl;

--- a/lib/uhd/uhd_source_c.cc
+++ b/lib/uhd/uhd_source_c.cc
@@ -81,6 +81,7 @@ uhd_source_c::uhd_source_c(const std::string &args) :
          "nchan" == entry.first ||
          "subdev" == entry.first ||
          "lo_offset" == entry.first ||
+         "clock_source" == entry.first ||
          "uhd" == entry.first )
       continue;
 
@@ -109,6 +110,9 @@ uhd_source_c::uhd_source_c(const std::string &args) :
 
   if (dict.count("subdev"))
     _src->set_subdev_spec( dict["subdev"] );
+
+  if (dict.count("clock_source"))
+    _src->set_clock_source( dict["clock_source"] );
 
   std::cerr << "-- Using subdev spec '" << _src->get_subdev_spec() << "'."
             << std::endl;


### PR DESCRIPTION
This patch allows to set the clock_source parameter from programs like gqrx. Typical values for clock_source= are "internal", "external" or "gpsdo".