### PR TITLE
Explicitly cast to command struct to prevent compile errors

### DIFF
--- a/lib/rtl_tcp/rtl_tcp_source_c.cc
+++ b/lib/rtl_tcp/rtl_tcp_source_c.cc
@@ -298,17 +298,17 @@ rtl_tcp_source_c::rtl_tcp_source_c(const std::string &args) :
   // set direct sampling
   struct command cmd;
 
-  cmd = { 0x09, htonl(direct_samp) };
+  cmd = (struct command){ 0x09, htonl(direct_samp) };
   send(d_socket, (const char*)&cmd, sizeof(cmd), 0);
   if (direct_samp)
     _no_tuner = true;
 
   // set offset tuning
-  cmd = { 0x0a, htonl(offset_tune) };
+  cmd = (struct command){ 0x0a, htonl(offset_tune) };
   send(d_socket, (const char*)&cmd, sizeof(cmd), 0);
 
   // set bias tee
-  cmd = { 0x0e, htonl(bias_tee) };
+  cmd = (struct command){ 0x0e, htonl(bias_tee) };
   send(d_socket, (const char*)&cmd, sizeof(cmd), 0);
 }
 
@@ -567,7 +567,7 @@ bool rtl_tcp_source_c::set_gain_mode( bool automatic, size_t chan )
   send(d_socket, (const char*)&cmd, sizeof(cmd), 0);
 
   // AGC mode
-  cmd = { 0x08, htonl(automatic) };
+  cmd = (struct command){ 0x08, htonl(automatic) };
   send(d_socket, (const char*)&cmd, sizeof(cmd), 0);
 
   _auto_gain = automatic;


### PR DESCRIPTION
Seeing these build errors running `make` on macOS 10.13.2 with the default version of clang shipping with Xcode. This patch resolves them (and compilation completes successfully) by explicitly casting to `struct command`.
```
Building CXX object lib/CMakeFiles/gnuradio-osmosdr.dir/rtl_tcp/rtl_tcp_source_c.cc.o
lib/rtl_tcp/rtl_tcp_source_c.cc:301:9: error: expected expression
  cmd = { 0x09, htonl(direct_samp) };
        ^
lib/rtl_tcp/rtl_tcp_source_c.cc:307:9: error: expected expression
  cmd = { 0x0a, htonl(offset_tune) };
        ^
lib/rtl_tcp/rtl_tcp_source_c.cc:311:9: error: expected expression
  cmd = { 0x0e, htonl(bias_tee) };
        ^
lib/rtl_tcp/rtl_tcp_source_c.cc:570:9: error: expected expression
  cmd = { 0x08, htonl(automatic) };
        ^
4 errors generated.
make[2]: *** [lib/CMakeFiles/gnuradio-osmosdr.dir/rtl_tcp/rtl_tcp_source_c.cc.o] Error 1
make[1]: *** [lib/CMakeFiles/gnuradio-osmosdr.dir/all] Error 2
make: *** [all] Error 2
```
```
﻿Apple LLVM version 9.0.0 (clang-900.0.39.2)
Target: x86_64-apple-darwin17.3.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```