### PR TITLE
Fix compilation with boost-1.67

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -43,6 +43,8 @@ GR_OSMOSDR_APPEND_SRCS(
     time_spec.cc
 )
 
+list(APPEND Boost_LIBRARIES pthread)
+
 GR_OSMOSDR_APPEND_LIBS(
     ${Boost_LIBRARIES}
     ${GNURADIO_ALL_LIBRARIES}


### PR DESCRIPTION
Fix compilation with boost-1.67,
since it now requires you to spec "pthread" as one of the used libraries.