### PR TITLE
hackrf: improved performance by changing _lut to realtime conversion

### DIFF
--- a/lib/hackrf/hackrf_source_c.h
+++ b/lib/hackrf/hackrf_source_c.h
@@ -129,8 +129,6 @@ private:
   static int _usage;
   static boost::mutex _usage_mutex;
 
-  std::vector<gr_complex> _lut;
-
   hackrf_device *_dev;
   gr::thread::thread _thread;
   unsigned short **_buf;


### PR DESCRIPTION
With this patch the conversion between int8_t and float is done without the _lut table. _lut is a 65k (*4) table which does not even fit in L1 cache. With this patch, and with -march=native the compiler is also able to automatically vectorize the code (AVX/SSE).

Signed-off-by: Alain Carlucci <alain.carlucci@gmail.com>