### PR TITLE
cmake: Go back CMake min ver. 3.8 by removing need for CMP0079

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,14 +20,13 @@
 ########################################################################
 # Project setup
 ########################################################################
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.8)
 include(GNUInstallDirs)
 project(gr-osmosdr CXX C)
 enable_testing()
 
 #policy setup
 cmake_policy(SET CMP0011 NEW)
-cmake_policy(SET CMP0079 NEW)
 
 #select the release build type by default to get optimization flags
 if(NOT CMAKE_BUILD_TYPE)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -41,7 +41,7 @@ if(CMAKE_COMPILER_IS_GNUCXX)
 endif()
 
 add_library(gnuradio-osmosdr SHARED)
-target_link_libraries(gnuradio-osmosdr ${Boost_LIBRARIES} gnuradio::gnuradio-runtime)
+list(APPEND gr_osmosdr_libs ${Boost_LIBRARIES} gnuradio::gnuradio-runtime)
 target_include_directories(gnuradio-osmosdr
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
     PUBLIC ${Boost_INCLUDE_DIRS}
@@ -100,7 +100,7 @@ CHECK_CXX_SOURCE_COMPILES("
 if(HAVE_CLOCK_GETTIME)
     message(STATUS "  High resolution timing supported through clock_gettime.")
     set(TIME_SPEC_DEFS HAVE_CLOCK_GETTIME)
-    target_link_libraries(gnuradio-osmosdr "-lrt")
+    list(APPEND gr_osmosdr_libs "-lrt")
 elseif(HAVE_MACH_ABSOLUTE_TIME)
     message(STATUS "  High resolution timing supported through mach_absolute_time.")
     set(TIME_SPEC_DEFS HAVE_MACH_ABSOLUTE_TIME)
@@ -124,7 +124,7 @@ GR_REGISTER_COMPONENT("Osmocom IQ Imbalance Correction" ENABLE_IQBALANCE gnuradi
 if(ENABLE_IQBALANCE)
     add_definitions(-DHAVE_IQBALANCE=1)
     target_include_directories(gnuradio-osmosdr PRIVATE ${gnuradio-iqbalance_INCLUDE_DIRS})
-    target_link_libraries(gnuradio-osmosdr gnuradio::gnuradio-iqbalance)
+    list(APPEND gr_osmosdr_libs gnuradio::gnuradio-iqbalance)
 endif(ENABLE_IQBALANCE)
 
 ########################################################################
@@ -263,6 +263,7 @@ configure_file(
 # Finalize target
 ########################################################################
 set_target_properties(gnuradio-osmosdr PROPERTIES SOURCES "${gr_osmosdr_srcs}")
+target_link_libraries(gnuradio-osmosdr ${gr_osmosdr_libs})
 
 ########################################################################
 # Install built library files

--- a/lib/airspy/CMakeLists.txt
+++ b/lib/airspy/CMakeLists.txt
@@ -26,7 +26,7 @@ target_include_directories(gnuradio-osmosdr PRIVATE
     ${LIBAIRSPY_INCLUDE_DIRS}
 )
 
-target_link_libraries(gnuradio-osmosdr
+list(APPEND gr_osmosdr_libs
     gnuradio::gnuradio-filter
     ${Gnuradio-blocks_LIBRARIES}
     ${LIBAIRSPY_LIBRARIES}

--- a/lib/airspyhf/CMakeLists.txt
+++ b/lib/airspyhf/CMakeLists.txt
@@ -26,7 +26,7 @@ target_include_directories(gnuradio-osmosdr PRIVATE
     ${LIBAIRSPYHF_INCLUDE_DIRS}
 )
 
-target_link_libraries(gnuradio-osmosdr
+list(APPEND gr_osmosdr_libs
     ${Gnuradio-blocks_LIBRARIES}
     ${LIBAIRSPYHF_LIBRARIES}
 )

--- a/lib/bladerf/CMakeLists.txt
+++ b/lib/bladerf/CMakeLists.txt
@@ -27,7 +27,7 @@ target_include_directories(gnuradio-osmosdr PRIVATE
     ${Volk_INCLUDE_DIRS}
 )
 
-target_link_libraries(gnuradio-osmosdr
+list(APPEND gr_osmosdr_libs
     ${LIBBLADERF_LIBRARIES}
     ${Volk_LIBRARIES}
 )

--- a/lib/fcd/CMakeLists.txt
+++ b/lib/fcd/CMakeLists.txt
@@ -29,7 +29,8 @@ if(ENABLE_FCD)
     target_include_directories(gnuradio-osmosdr PRIVATE
         ${Gnuradio-fcd_INCLUDE_DIRS}
     )
-    target_link_libraries(gnuradio-osmosdr PRIVATE
+
+    list(APPEND gr_osmosdr_libs
         ${Gnuradio-fcd_LIBRARIES}
     )
 endif(ENABLE_FCD)
@@ -38,7 +39,7 @@ if(ENABLE_FCDPP)
     target_include_directories(gnuradio-osmosdr PRIVATE
         ${Gnuradio-fcdpp_INCLUDE_DIRS}
     )
-    target_link_libraries(gnuradio-osmosdr PRIVATE
+    list(APPEND gr_osmosdr_libs
         ${Gnuradio-fcdpp_LIBRARIES}
     )
 endif(ENABLE_FCDPP)

--- a/lib/file/CMakeLists.txt
+++ b/lib/file/CMakeLists.txt
@@ -25,7 +25,7 @@ target_include_directories(gnuradio-osmosdr PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-target_link_libraries(gnuradio-osmosdr
+list(APPEND gr_osmosdr_libs
     gnuradio::gnuradio-blocks
 )
 message(STATUS ${gnuradio-blocks_LIBRARIES})

--- a/lib/freesrp/CMakeLists.txt
+++ b/lib/freesrp/CMakeLists.txt
@@ -26,7 +26,7 @@ target_include_directories(gnuradio-osmosdr PRIVATE
     ${LIBFREESRP_INCLUDE_DIRS}
 )
 
-target_link_libraries(gnuradio-osmosdr
+list(APPEND gr_osmosdr_libs
     ${LIBFREESRP_LIBRARIES}
 )
 

--- a/lib/hackrf/CMakeLists.txt
+++ b/lib/hackrf/CMakeLists.txt
@@ -26,7 +26,7 @@ target_include_directories(gnuradio-osmosdr PRIVATE
     ${LIBHACKRF_INCLUDE_DIRS}
 )
 
-target_link_libraries(gnuradio-osmosdr
+list(APPEND gr_osmosdr_libs
     ${LIBHACKRF_LIBRARIES}
 )
 

--- a/lib/miri/CMakeLists.txt
+++ b/lib/miri/CMakeLists.txt
@@ -26,7 +26,7 @@ target_include_directories(gnuradio-osmosdr PRIVATE
     ${LIBMIRISDR_INCLUDE_DIRS}
 )
 
-target_link_libraries(gnuradio-osmosdr
+list(APPEND gr_osmosdr_libs
     ${LIBMIRISDR_LIBRARIES}
 )
 

--- a/lib/osmosdr/CMakeLists.txt
+++ b/lib/osmosdr/CMakeLists.txt
@@ -26,7 +26,7 @@ target_include_directories(gnuradio-osmosdr PRIVATE
     ${LIBOSMOSDR_INCLUDE_DIRS}
 )
 
-target_link_libraries(gnuradio-osmosdr
+list(APPEND gr_osmosdr_libs
     ${LIBOSMOSDR_LIBRARIES}
 )
 

--- a/lib/redpitaya/CMakeLists.txt
+++ b/lib/redpitaya/CMakeLists.txt
@@ -25,7 +25,7 @@ target_include_directories(gnuradio-osmosdr PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-target_link_libraries(gnuradio-osmosdr
+list(APPEND gr_osmosdr_libs
     ${Gnuradio-blocks_LIBRARIES}
 )
 

--- a/lib/rtl/CMakeLists.txt
+++ b/lib/rtl/CMakeLists.txt
@@ -26,7 +26,7 @@ target_include_directories(gnuradio-osmosdr PRIVATE
     ${LIBRTLSDR_INCLUDE_DIRS}
 )
 
-target_link_libraries(gnuradio-osmosdr
+list(APPEND gr_osmosdr_libs
     ${LIBRTLSDR_LIBRARIES}
 )
 

--- a/lib/rtl_tcp/CMakeLists.txt
+++ b/lib/rtl_tcp/CMakeLists.txt
@@ -25,7 +25,7 @@ target_include_directories(gnuradio-osmosdr PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-target_link_libraries(gnuradio-osmosdr
+list(APPEND gr_osmosdr_libs
     ${Gnuradio-blocks_LIBRARIES}
 )
 

--- a/lib/sdrplay/CMakeLists.txt
+++ b/lib/sdrplay/CMakeLists.txt
@@ -26,7 +26,7 @@ target_include_directories(gnuradio-osmosdr PRIVATE
     ${LIBSDRPLAY_INCLUDE_DIRS}
 )
 
-target_link_libraries(gnuradio-osmosdr
+list(APPEND gr_osmosdr_libs
     ${LIBSDRPLAY_LIBRARIES}
 )
 

--- a/lib/soapy/CMakeLists.txt
+++ b/lib/soapy/CMakeLists.txt
@@ -26,7 +26,7 @@ target_include_directories(gnuradio-osmosdr PRIVATE
     ${SoapySDR_INCLUDE_DIRS}
 )
 
-target_link_libraries(gnuradio-osmosdr
+list(APPEND gr_osmosdr_libs
     ${SoapySDR_LIBRARIES}
 )
 

--- a/lib/uhd/CMakeLists.txt
+++ b/lib/uhd/CMakeLists.txt
@@ -27,7 +27,7 @@ target_include_directories(gnuradio-osmosdr PRIVATE
     ${UHD_INCLUDE_DIRS}
 )
 
-target_link_libraries(gnuradio-osmosdr
+list(APPEND gr_osmosdr_libs
     gnuradio::gnuradio-uhd
     ${UHD_LIBRARIES}
 )


### PR DESCRIPTION
CMake 3.13 is not present in older (~2 years old)
Linux distributions. GNU Radio itself is not that restrictive
(it requires min CMake version 3.8).

All that is needed in order to avoid bumping CMake version
is to not use 'target_link_libraries' in subdirectories.
Here this is done by creating a list of needed
libraries and adding them for linking at the end (like
it was done in gr-osmosdr before porting to GNU Radio 3.8).

Only thing that is lost is PRIVATE statement in case of FCD 
libraries.