### PR TITLE
fix breakage with current gnuradio maint-3.9

### DIFF
--- a/apps/osmocom_fft
+++ b/apps/osmocom_fft
@@ -288,7 +288,8 @@ class app_top_block(gr.top_block, Qt.QMainWindow):
                 plotfreq=True,
                 plotwaterfall=True,
                 plottime=True,
-                plotconst=True
+                plotconst=True,
+                parent=None
             )
             if hasattr(self.scope,'pyqwidget'):
                 self.scope_win = sip.wrapinstance(self.scope.pyqwidget(), Qt.QWidget)

--- a/apps/osmocom_fft
+++ b/apps/osmocom_fft
@@ -317,7 +317,7 @@ class app_top_block(gr.top_block, Qt.QMainWindow):
         try:
             self.freq = freq_recv(self.set_freq)
             self.msg_connect((self.scope, 'freq'), (self.freq, 'msg'))
-        except RuntimeError:
+        except (RuntimeError, ValueError):
             self.freq = None
 
         self.file_sink = blocks.file_sink(gr.sizeof_gr_complex, "/dev/null", False)

--- a/apps/osmocom_fft
+++ b/apps/osmocom_fft
@@ -242,7 +242,10 @@ class app_top_block(gr.top_block, Qt.QMainWindow):
             from gnuradio import fosphor
             self.scope = fosphor.qt_sink_c()
             self.scope.set_frequency_range(0, input_rate)
-            self.scope_win = sip.wrapinstance(self.scope.pyqwidget(), Qt.QWidget)
+            if hasattr(self.scope,'pyqwidget'):
+                self.scope_win = sip.wrapinstance(self.scope.pyqwidget(), Qt.QWidget)
+            else:
+                self.scope_win = sip.wrapinstance(self.scope.qwidget(), Qt.QWidget)
             self.scope_win.setMinimumSize(800, 300)
         elif options.waterfall:
             self.scope = qtgui.waterfall_sink_c(
@@ -256,7 +259,10 @@ class app_top_block(gr.top_block, Qt.QMainWindow):
             self.scope.enable_grid(False)
             self.scope.enable_axis_labels(True)
             self.scope.set_intensity_range(-100, 20)
-            self.scope_win = sip.wrapinstance(self.scope.pyqwidget(), Qt.QWidget)
+            if hasattr(self.scope,'pyqwidget'):
+                self.scope_win = sip.wrapinstance(self.scope.pyqwidget(), Qt.QWidget)
+            else:
+                self.scope_win = sip.wrapinstance(self.scope.qwidget(), Qt.QWidget)
             self.scope_win.setMinimumSize(800, 420)
 
         elif options.oscilloscope:
@@ -266,7 +272,10 @@ class app_top_block(gr.top_block, Qt.QMainWindow):
                 name="",
                 nconnections=1
             )
-            self.scope_win = sip.wrapinstance(self.scope.pyqwidget(), Qt.QWidget)
+            if hasattr(self.scope,'pyqwidget'):
+                self.scope_win = sip.wrapinstance(self.scope.pyqwidget(), Qt.QWidget)
+            else:
+                self.scope_win = sip.wrapinstance(self.scope.qwidget(), Qt.QWidget)
             self.scope_win.setMinimumSize(800, 600)
 
         elif options.qtgui:
@@ -281,7 +290,10 @@ class app_top_block(gr.top_block, Qt.QMainWindow):
                 plottime=True,
                 plotconst=True
             )
-            self.scope_win = sip.wrapinstance(self.scope.pyqwidget(), Qt.QWidget)
+            if hasattr(self.scope,'pyqwidget'):
+                self.scope_win = sip.wrapinstance(self.scope.pyqwidget(), Qt.QWidget)
+            else:
+                self.scope_win = sip.wrapinstance(self.scope.qwidget(), Qt.QWidget)
             self.scope.set_update_time(1.0/10)
             self.scope_win.setMinimumSize(800, 600)
 
@@ -294,7 +306,10 @@ class app_top_block(gr.top_block, Qt.QMainWindow):
                 name="",
                 nconnections=1
             )
-            self.scope_win = sip.wrapinstance(self.scope.pyqwidget(), Qt.QWidget)
+            if hasattr(self.scope,'pyqwidget'):
+                self.scope_win = sip.wrapinstance(self.scope.pyqwidget(), Qt.QWidget)
+            else:
+                self.scope_win = sip.wrapinstance(self.scope.qwidget(), Qt.QWidget)
             self.scope.disable_legend()
             self.scope_win.setMinimumSize(800, 420)
 


### PR DESCRIPTION
Gnuradio recently changed the pyqwidget wrapper - we're now supposed to use qwidget directly.
See https://github.com/gnuradio/gnuradio/commit/86b5fb30182c69ec38490346a4269d1ffce9ffb4

Additionally two more small fixes to make "-Q" and "-S" also work again