### PR TITLE
switch to cmake 3.13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@
 ########################################################################
 # Project setup
 ########################################################################
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.13)
 project(gr-osmosdr CXX C)
 include(GNUInstallDirs)
 enable_testing()

--- a/README.md
+++ b/README.md
@@ -48,11 +48,9 @@ Building with cmake:
 ```
 git clone https://gitea.osmocom.org/sdr/gr-osmosdr
 cd gr-osmosdr/
-mkdir build
-cd build/
-cmake ../
-make
-sudo make install
+cmake -S . -B build
+cmake --build build --parallel
+sudo cmake --install build
 sudo ldconfig
 ```
 


### PR DESCRIPTION
stop to use make because since CMake 3.15 (Ubuntu 20.04), Generator can be set in env CMAKE_GENERATOR and sometimes it is not the Unix Makefiles; Tested in Ubuntu 24

P.S. I can't contribute to https://gitea.osmocom.org/sdr/gr-osmosdr because https://osmocom.org/issues/6739