### PR TITLE
cmake: remove system component from boost

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,7 @@ endif()
 ########################################################################
 # Find boost
 ########################################################################
-find_package(Boost "1.65" REQUIRED chrono thread system)
+find_package(Boost "1.69" REQUIRED chrono thread)
 
 if(NOT Boost_FOUND)
     message(FATAL_ERROR "Boost required to compile osmosdr")


### PR DESCRIPTION
After bumping boost from 1.87 to 1.89 we noticed this failure without this patch:

```
CMake Error at /nix/store/adv73gqmglkg48w5ql70s778ba6wpbs4-boost-1.89.0-dev/lib/cmake/Boost-1.89.0/BoostConfig.cmake:141 (find_package):
  Could not find a package configuration file provided by "boost_system"
  (requested version 1.89.0) with any of the following names:

    boost_systemConfig.cmake
    boost_system-config.cmake

  Add the installation prefix of "boost_system" to CMAKE_PREFIX_PATH or set
  "boost_system_DIR" to a directory containing one of the above files.  If
  "boost_system" provides a separate development package or SDK, be sure it
  has been installed.
```
